### PR TITLE
INS-39698

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.kafka.instaclustr</groupId>
     <artifactId>apache-kafka-client-metrics-reporter-plugin</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/instaclustr/kafka/KafkaClientMetricsReporter.java
+++ b/src/main/java/com/instaclustr/kafka/KafkaClientMetricsReporter.java
@@ -29,7 +29,7 @@ public class KafkaClientMetricsReporter implements MetricsReporter, ClientTeleme
 
     @Override
     public void init(List<KafkaMetric> metrics) {
-        logger.info("Initializing the client metric reporter: {}", metrics);
+        logger.info("Initializing the client metric reporter");
     }
 
     @Override

--- a/src/main/java/com/instaclustr/kafka/KafkaClientMetricsReporter.java
+++ b/src/main/java/com/instaclustr/kafka/KafkaClientMetricsReporter.java
@@ -20,12 +20,11 @@ import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.server.telemetry.ClientTelemetry;
 import org.apache.kafka.server.telemetry.ClientTelemetryReceiver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.instaclustr.kafka.logging.KafkaClientMetricsLogger;
 
 public class KafkaClientMetricsReporter implements MetricsReporter, ClientTelemetry {
 
-    private static final Logger logger = LoggerFactory.getLogger(KafkaClientMetricsReporter.class);
+    private static final KafkaClientMetricsLogger logger = KafkaClientMetricsLogger.getLogger(KafkaClientMetricsReporter.class);
 
 
     @Override

--- a/src/main/java/com/instaclustr/kafka/KafkaClientMetricsReporterConfig.java
+++ b/src/main/java/com/instaclustr/kafka/KafkaClientMetricsReporterConfig.java
@@ -14,8 +14,7 @@ limitations under the License.
 
 package com.instaclustr.kafka;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.instaclustr.kafka.logging.KafkaClientMetricsLogger;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.FileInputStream;
@@ -24,7 +23,7 @@ import java.util.Map;
 public class KafkaClientMetricsReporterConfig {
 
     public Map<String, Object> configurations;
-    private static final Logger logger = LoggerFactory.getLogger(KafkaClientMetricsReporterConfig.class);
+    private static final KafkaClientMetricsLogger logger = KafkaClientMetricsLogger.getLogger(KafkaClientMetricsReporterConfig.class);
 
     public KafkaClientMetricsReporterConfig() {
         this(System.getenv("KAFKA_CLIENT_METRICS_CONFIG_PATH"));

--- a/src/main/java/com/instaclustr/kafka/KafkaClientMetricsReporterReceiver.java
+++ b/src/main/java/com/instaclustr/kafka/KafkaClientMetricsReporterReceiver.java
@@ -16,16 +16,15 @@ package com.instaclustr.kafka;
 
 import com.instaclustr.kafka.exporters.MetricsExporter;
 import com.instaclustr.kafka.exporters.MetricsExporterFactory;
+import com.instaclustr.kafka.logging.KafkaClientMetricsLogger;
 import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.apache.kafka.server.telemetry.ClientTelemetryPayload;
 import org.apache.kafka.server.telemetry.ClientTelemetryReceiver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class KafkaClientMetricsReporterReceiver implements ClientTelemetryReceiver {
 
     private final MetricsExporter metricsExporter;
-    private static final Logger logger = LoggerFactory.getLogger(KafkaClientMetricsReporterReceiver.class);
+    private static final KafkaClientMetricsLogger logger = KafkaClientMetricsLogger.getLogger(KafkaClientMetricsReporterReceiver.class);
 
     public KafkaClientMetricsReporterReceiver() {
         logger.info("Initializing the Kafka Client Metrics Reporter Receiver");

--- a/src/main/java/com/instaclustr/kafka/exporters/HttpMetricsExporter.java
+++ b/src/main/java/com/instaclustr/kafka/exporters/HttpMetricsExporter.java
@@ -15,10 +15,9 @@ limitations under the License.
 package com.instaclustr.kafka.exporters;
 
 import com.instaclustr.kafka.helpers.MetricsMetaDataProcessor;
+import com.instaclustr.kafka.logging.KafkaClientMetricsLogger;
 import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.apache.kafka.server.telemetry.ClientTelemetryPayload;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -30,7 +29,7 @@ public class HttpMetricsExporter implements MetricsExporter {
     private final String endpoint;
     private final HttpClient httpClient;
     final Map<String, Object> metadata;
-    private final Logger logger = LoggerFactory.getLogger(HttpMetricsExporter.class);
+    private final KafkaClientMetricsLogger logger = KafkaClientMetricsLogger.getLogger(HttpMetricsExporter.class);
 
     public HttpMetricsExporter(final String endpoint, final int timeoutMillis, final Map<String, Object> metadata) {
         this.endpoint = endpoint;

--- a/src/main/java/com/instaclustr/kafka/exporters/HttpMetricsExporter.java
+++ b/src/main/java/com/instaclustr/kafka/exporters/HttpMetricsExporter.java
@@ -32,11 +32,13 @@ public class HttpMetricsExporter implements MetricsExporter {
     final Map<String, Object> metadata;
     private final MetricsMetaDataProcessor metricsMetaDataProcessor;
     private final KafkaClientMetricsLogger logger = KafkaClientMetricsLogger.getLogger(HttpMetricsExporter.class);
+    private final Duration timeoutMillisDuration;
 
     public HttpMetricsExporter(final String endpoint, final int timeoutMillis, final Map<String, Object> metadata) {
         this.endpoint = endpoint;
         this.metadata = metadata != null ? metadata : Collections.emptyMap();
         this.metricsMetaDataProcessor = new MetricsMetaDataProcessor(this.metadata);
+        this.timeoutMillisDuration = Duration.ofMillis(timeoutMillis);
         this.httpClient = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_2)
                 .connectTimeout(Duration.ofMillis(timeoutMillis))
@@ -61,6 +63,7 @@ public class HttpMetricsExporter implements MetricsExporter {
                 .uri(URI.create(endpoint))
                 .header("Content-Type", "application/x-protobuf")
                 .POST(HttpRequest.BodyPublishers.ofByteArray(payload))
+                .timeout(this.timeoutMillisDuration)
                 .build();
     }
 

--- a/src/main/java/com/instaclustr/kafka/exporters/MetricsExporterFactory.java
+++ b/src/main/java/com/instaclustr/kafka/exporters/MetricsExporterFactory.java
@@ -14,6 +14,7 @@ limitations under the License.
 
 package com.instaclustr.kafka.exporters;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class MetricsExporterFactory {
@@ -33,7 +34,7 @@ public class MetricsExporterFactory {
         if (metadataObj != null && !(metadataObj instanceof Map)) {
             throw new IllegalArgumentException("Metadata configuration is not a valid map");
         }
-        final Map<String, Object> metadata = (Map<String, Object>) metadataObj;
+        final Map<String, Object> metadata = metadataObj != null ? (Map<String, Object>) metadataObj : Collections.emptyMap();
 
         switch (((String) exporterMap.get("mode")).toUpperCase()) {
             case "HTTP":

--- a/src/main/java/com/instaclustr/kafka/helpers/MetricsMetaDataProcessor.java
+++ b/src/main/java/com/instaclustr/kafka/helpers/MetricsMetaDataProcessor.java
@@ -14,6 +14,7 @@ limitations under the License.
 
 package com.instaclustr.kafka.helpers;
 
+import com.instaclustr.kafka.logging.KafkaClientMetricsLogger;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.requests.RequestContext;
@@ -24,8 +25,6 @@ import org.apache.kafka.shaded.io.opentelemetry.proto.common.v1.AnyValue;
 import org.apache.kafka.shaded.io.opentelemetry.proto.common.v1.KeyValue;
 import org.apache.kafka.shaded.io.opentelemetry.proto.metrics.v1.MetricsData;
 import org.apache.kafka.shaded.io.opentelemetry.proto.resource.v1.Resource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -35,7 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class MetricsMetaDataProcessor {
-    private static final Logger logger = LoggerFactory.getLogger(MetricsMetaDataProcessor.class);
+    private static final KafkaClientMetricsLogger logger = KafkaClientMetricsLogger.getLogger(MetricsMetaDataProcessor.class);
     private final Map<String, Object> metadata;
 
 

--- a/src/main/java/com/instaclustr/kafka/helpers/MetricsMetaDataProcessor.java
+++ b/src/main/java/com/instaclustr/kafka/helpers/MetricsMetaDataProcessor.java
@@ -29,17 +29,29 @@ import org.apache.kafka.shaded.io.opentelemetry.proto.resource.v1.Resource;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class MetricsMetaDataProcessor {
     private static final KafkaClientMetricsLogger logger = KafkaClientMetricsLogger.getLogger(MetricsMetaDataProcessor.class);
-    private final Map<String, Object> metadata;
+    private final List<KeyValue> staticMetadataAttributes;
 
 
     public MetricsMetaDataProcessor(final Map<String, Object> metadata) {
-        this.metadata = metadata;
+        this.staticMetadataAttributes = toStaticAttributes(metadata);
+    }
+
+    public static List<KeyValue> toStaticAttributes(final Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final List<KeyValue> attrs = new ArrayList<>(metadata.size());
+        metadata.forEach((key, value) -> attrs.add(toKeyValue(key, value)));
+        return attrs;
     }
 
     public byte[] processMetricsData(final AuthorizableRequestContext requestContext, final ByteBuffer buffer) {
@@ -118,7 +130,7 @@ public class MetricsMetaDataProcessor {
     }
 
     private boolean shouldEnrichStaticMetaData(final MetricsData metricsData) {
-        return !this.metadata.isEmpty() && metricsData.getResourceMetricsCount() > 0;
+        return !this.staticMetadataAttributes.isEmpty() && metricsData.getResourceMetricsCount() > 0;
     }
 
     private byte[] enrichMetricsData(final AuthorizableRequestContext context, MetricsData metricsData) {
@@ -137,44 +149,61 @@ public class MetricsMetaDataProcessor {
             Resource.Builder resourceBuilder =
                     dataBuilder.getResourceMetricsBuilder(i).getResourceBuilder();
 
-            this.metadata.forEach((key, value) ->
-                    resourceBuilder.addAttributes(toKeyValue(key, value))
-            );
+            resourceBuilder.addAllAttributes(staticMetadataAttributes);
         }
     }
 
     private void enrichDynamicMetadata(final AuthorizableRequestContext context, MetricsData.Builder dataBuilder) {
 
         final RequestContext requestContext = (RequestContext) context;
-
-        Map<String, String> dynamicMetadata = new HashMap<>();
-        if (requestContext.clientId() != null) {
-            dynamicMetadata.put("clientId", requestContext.clientId());
-        }
-        if (requestContext.clientInformation != null) {
-            dynamicMetadata.put("clientSoftwareName", requestContext.clientInformation.softwareName());
-            dynamicMetadata.put("clientSoftwareVersion", requestContext.clientInformation.softwareVersion());
+        final List<KeyValue> dynamicAttributes = buildDynamicAttributes(requestContext);
+        if (dynamicAttributes.isEmpty()) {
+            return;
         }
 
         for (int i = 0; i < dataBuilder.getResourceMetricsCount(); i++) {
             Resource.Builder resourceBuilder = dataBuilder.getResourceMetricsBuilder(i).getResourceBuilder();
-            dynamicMetadata.forEach((key, value) -> resourceBuilder.addAttributes(
-                    KeyValue.newBuilder()
-                            .setKey(key)
-                            .setValue(AnyValue.newBuilder().setStringValue(value))
-                            .build()
-            ));
+            resourceBuilder.addAllAttributes(dynamicAttributes);
         }
     }
 
-    private KeyValue toKeyValue(final String key, final Object value) {
+    private static List<KeyValue> buildDynamicAttributes(final RequestContext requestContext) {
+        final String clientId = requestContext.clientId();
+        final String softwareName = requestContext.clientInformation != null ? requestContext.clientInformation.softwareName() : null;
+        final String softwareVersion = requestContext.clientInformation != null ? requestContext.clientInformation.softwareVersion() : null;
+
+        if (clientId == null && softwareName == null && softwareVersion == null) {
+            return Collections.emptyList();
+        }
+
+        final List<KeyValue> attrs = new ArrayList<>(3);
+        if (clientId != null) {
+            attrs.add(toStringKeyValue("clientId", clientId));
+        }
+        if (softwareName != null) {
+            attrs.add(toStringKeyValue("clientSoftwareName", softwareName));
+        }
+        if (softwareVersion != null) {
+            attrs.add(toStringKeyValue("clientSoftwareVersion", softwareVersion));
+        }
+        return attrs;
+    }
+
+    private static KeyValue toStringKeyValue(final String key, final String value) {
+        return KeyValue.newBuilder()
+                .setKey(key)
+                .setValue(AnyValue.newBuilder().setStringValue(value).build())
+                .build();
+    }
+
+    private static KeyValue toKeyValue(final String key, final Object value) {
         return KeyValue.newBuilder()
                 .setKey(key)
                 .setValue(toAnyValue(value))
                 .build();
     }
 
-    private AnyValue toAnyValue(final Object value) {
+    private static AnyValue toAnyValue(final Object value) {
         AnyValue.Builder b = AnyValue.newBuilder();
         if (value instanceof String) {
             b.setStringValue((String) value);

--- a/src/main/java/com/instaclustr/kafka/logging/KafkaClientMetricsLogger.java
+++ b/src/main/java/com/instaclustr/kafka/logging/KafkaClientMetricsLogger.java
@@ -1,0 +1,118 @@
+/*
+Copyright 2021 Instaclustr Pty Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.instaclustr.kafka.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Small logger wrapper that prefixes every log line with a constant label so
+ * plugin logs are easy to spot in Kafka process logs, regardless of the SLF4J backend.
+ */
+public final class KafkaClientMetricsLogger {
+
+    public static final String PREFIX = "[Apache Kafka Client Metrics Reporter Plugin] ";
+
+    private final Logger delegate;
+
+    private KafkaClientMetricsLogger(final Logger delegate) {
+        this.delegate = delegate;
+    }
+
+    public static KafkaClientMetricsLogger getLogger(final Class<?> clazz) {
+        return new KafkaClientMetricsLogger(LoggerFactory.getLogger(clazz));
+    }
+
+    public boolean isTraceEnabled() {
+        return delegate.isTraceEnabled();
+    }
+
+    public boolean isDebugEnabled() {
+        return delegate.isDebugEnabled();
+    }
+
+    public boolean isInfoEnabled() {
+        return delegate.isInfoEnabled();
+    }
+
+    public boolean isWarnEnabled() {
+        return delegate.isWarnEnabled();
+    }
+
+    public boolean isErrorEnabled() {
+        return delegate.isErrorEnabled();
+    }
+
+    public void trace(final String message) {
+        delegate.trace(PREFIX + message);
+    }
+
+    public void trace(final String message, final Object... args) {
+        delegate.trace(PREFIX + message, args);
+    }
+
+    public void trace(final String message, final Throwable t) {
+        delegate.trace(PREFIX + message, t);
+    }
+
+    public void debug(final String message) {
+        delegate.debug(PREFIX + message);
+    }
+
+    public void debug(final String message, final Object... args) {
+        delegate.debug(PREFIX + message, args);
+    }
+
+    public void debug(final String message, final Throwable t) {
+        delegate.debug(PREFIX + message, t);
+    }
+
+    public void info(final String message) {
+        delegate.info(PREFIX + message);
+    }
+
+    public void info(final String message, final Object... args) {
+        delegate.info(PREFIX + message, args);
+    }
+
+    public void info(final String message, final Throwable t) {
+        delegate.info(PREFIX + message, t);
+    }
+
+    public void warn(final String message) {
+        delegate.warn(PREFIX + message);
+    }
+
+    public void warn(final String message, final Object... args) {
+        delegate.warn(PREFIX + message, args);
+    }
+
+    public void warn(final String message, final Throwable t) {
+        delegate.warn(PREFIX + message, t);
+    }
+
+    public void error(final String message) {
+        delegate.error(PREFIX + message);
+    }
+
+    public void error(final String message, final Object... args) {
+        delegate.error(PREFIX + message, args);
+    }
+
+    public void error(final String message, final Throwable t) {
+        delegate.error(PREFIX + message, t);
+    }
+}
+


### PR DESCRIPTION
While testing a Kafka 4.1.1 build with the plugin we noticed there were some errors from the plugin,

```
Jan 30 05:01:53 ip-10-0-34-230 kafka[2798]: [2026-01-30 05:01:53,407] ERROR Error processing metrics data: Protocol message contained an invalid tag (zero). (com.instaclustr.kafka.helpers.MetricsMetaDataProcessor)
Jan 30 05:01:53 ip-10-0-34-230 kafka[2798]: org.apache.kafka.shaded.com.google.protobuf.InvalidProtocolBufferException: Protocol message contained an invalid tag (zero).
```
We identified the issue to be, when the ByteBuffer is backed by an array, we currently return the entire backing array and ignore position/limit. If Kafka passes a sliced buffer (common), we’ll parse extra bytes (often leading 0x00), which triggers the “invalid tag (zero)” protobuf error. This PR contains a fix for this issue.

We have also opportunistically made a few improvements to the plugin, this includes,

1. A wrapper logging class com.instaclustr.kafka.logging.KafkaClientMetricsLogger - Which prefixes `[Apache Kafka Client Metrics Reporter Plugin] ` to log entries. This makes it easier to detect log entries from the plugin in Kafka logs
2. A try catch iteration method to decompress metric payloads that could be compressed.
3. Improvements in loading various objects to help the plugin be more scalable.